### PR TITLE
Use relative imports for local c++ deps

### DIFF
--- a/torchrl/csrc/segment_tree.h
+++ b/torchrl/csrc/segment_tree.h
@@ -16,8 +16,8 @@
 #include <limits>
 #include <vector>
 
-#include "torchrl/csrc/numpy_utils.h"
-#include "torchrl/csrc/torch_utils.h"
+#include "numpy_utils.h"
+#include "torch_utils.h"
 
 namespace py = pybind11;
 


### PR DESCRIPTION
Usage of relative imports in cpp files allows to not rely on folder structure